### PR TITLE
Ajuste de regras de combate para Taekwondo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,22 @@
 ## Placar Taekwondo Mobile
 
-Código original feito por: Isaac Melo
+CÃ³digo original feito por: Isaac Melo
 
 ## Code 
 
 Angular
 
-## Pontuações
+## PontuaÃ§Ãµes jÃ¡ com a nova regra
 
-- Chute na cabeça vale 3 pontos
-- Chute no tronco vale 1 ponto
+- Chute na cabeÃ§a vale 3 pontos
+- Chute no tronco vale 2 pontos
+- Soco no tronco vale 1 ponto
+- Todos os chutes acertados ganham bonus de +1 ponto quanto feito com giro
 
-## Possíveis implementações
+## PossÃ­veis implementaÃ§Ãµes
 
 - Adicionar faltas
 - Adcionar rounds
 - Adicionar cronometro 
 - Adiocnar nomes dos lutadores
+- Refatorar cÃ³digo fonte


### PR DESCRIPTION
Em 2017 a WTF.org alterou as regras de pontuação em combate. Os ajustes foram feitos no README.md e em breve vamos alterar o código fonte.